### PR TITLE
회원가입 페이지 퍼블리싱

### DIFF
--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -64,7 +64,7 @@ const Page = () => {
                       {...field}
                     />
                   </FormControl>
-                  <Button>인증번호 발송</Button>
+                  <Button variant="outline">인증번호 발송</Button>
                 </div>
                 <FormMessage />
               </FormItem>
@@ -157,7 +157,9 @@ const Page = () => {
             />
           </div>
           <div className="flex justify-center">
-            <Button type="submit">가입하기</Button>
+            <Button type="submit" size="long">
+              가입하기
+            </Button>
           </div>
         </form>
       </Form>

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -15,18 +15,15 @@ import {
   InputOTPGroup,
   InputOTPSlot,
 } from '@/shared/ui/ui/input-otp';
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-  SelectGroup,
-} from '@/shared/ui/ui/select';
+import SelectComponent from '@/views/signUp/SelectComponent';
+
 import { useForm } from 'react-hook-form';
 
 const Page = () => {
   const form = useForm();
+
+  const collageItems = ['ICT융합대학', '경영대학', '사회과학대학'];
+  const departmentItems = ['융합소프트웨어학부', '법학과', '경영학과'];
 
   return (
     <>
@@ -70,7 +67,6 @@ const Page = () => {
               </FormItem>
             )}
           />
-
           <div className="space-y-2">
             <p className="text-sm cursor-default">인증 번호</p>
             <InputOTP maxLength={6}>
@@ -110,22 +106,10 @@ const Page = () => {
                 <FormItem>
                   <FormLabel>단과대 선택</FormLabel>
                   <FormControl>
-                    <Select>
-                      <SelectTrigger>
-                        <SelectValue placeholder="단과대를 선택해주세요." />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          <SelectItem value="경영대학">경영대학</SelectItem>
-                          <SelectItem value="사회과학대학">
-                            사회과학대학
-                          </SelectItem>
-                          <SelectItem value="ICT융합대학">
-                            ICT융합대학
-                          </SelectItem>
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
+                    <SelectComponent
+                      placeholder="단과대를 선택해주세요."
+                      items={collageItems}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -138,20 +122,10 @@ const Page = () => {
                 <FormItem>
                   <FormLabel>학과 선택</FormLabel>
                   <FormControl>
-                    <Select>
-                      <SelectTrigger>
-                        <SelectValue placeholder="학과를 선택해주세요." />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          <SelectItem value="경영학과">경영학과</SelectItem>
-                          <SelectItem value="융합소프트웨어학부">
-                            융합소프트웨어학부
-                          </SelectItem>
-                          <SelectItem value="법학과">법학과</SelectItem>
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
+                    <SelectComponent
+                      placeholder="학과를 선택해주세요."
+                      items={departmentItems}
+                    />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/src/app/signUp/page.tsx
+++ b/src/app/signUp/page.tsx
@@ -72,7 +72,7 @@ const Page = () => {
           />
 
           <div className="space-y-2">
-            <p className="text-sm">인증 번호</p>
+            <p className="text-sm cursor-default">인증 번호</p>
             <InputOTP maxLength={6}>
               <InputOTPGroup>
                 <InputOTPSlot index={0} />
@@ -108,6 +108,7 @@ const Page = () => {
               name="college"
               render={({ field }) => (
                 <FormItem>
+                  <FormLabel>단과대 선택</FormLabel>
                   <FormControl>
                     <Select>
                       <SelectTrigger>
@@ -135,10 +136,11 @@ const Page = () => {
               name="department"
               render={({ field }) => (
                 <FormItem>
+                  <FormLabel>학과 선택</FormLabel>
                   <FormControl>
                     <Select>
                       <SelectTrigger>
-                        <SelectValue placeholder="과를 선택해주세요." />
+                        <SelectValue placeholder="학과를 선택해주세요." />
                       </SelectTrigger>
                       <SelectContent>
                         <SelectGroup>

--- a/src/views/signUp/SelectComponent.tsx
+++ b/src/views/signUp/SelectComponent.tsx
@@ -1,0 +1,34 @@
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+  SelectGroup,
+} from '@/shared/ui/ui/select';
+
+interface SelectComponentProps {
+  placeholder: string;
+  items: string[];
+}
+
+const SelectComponent = ({ placeholder, items }: SelectComponentProps) => {
+  return (
+    <Select>
+      <SelectTrigger>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          {items.map((item, index) => (
+            <SelectItem key={index} value={item}>
+              {item}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default SelectComponent;


### PR DESCRIPTION
close #3 

<img width="1279" alt="image" src="https://github.com/user-attachments/assets/835df371-ee60-4bf3-a678-08d9862e1f62">

- 정말 퍼블리싱만 끝
- form, zod 관련 로직 없음
- 버튼 로직 없음 (인증, submi 관련)

(이슈)
- shadcn select 선택 시 갑자기 scroll-y가 사라짐

https://github.com/user-attachments/assets/03e8e23e-b658-4231-ac2b-181e055e0e6b


(나중에 할 것? 궁금한 점?)
- fsd.. 컴포넌트를 어디까지 분리해야 할 지 어려워서 일단 회원가입 페이지 안에서 공통으로 쓰는 select 부분은 빼놓긴 했음
- 타입은 그냥 해당 파일 안에 놔둠