### PR TITLE
공통 컴포넌트 > 헤더 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-label": "^2.1.0",
         "@radix-ui/react-select": "^2.1.1",
         "@radix-ui/react-slot": "^1.1.0",
+        "@radix-ui/react-tooltip": "^1.1.2",
         "@tanstack/react-query": "^5.50.1",
         "@types/node": "20.14.9",
         "@types/react": "18.3.3",
@@ -787,6 +788,30 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.0.tgz",
+      "integrity": "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz",
@@ -867,6 +892,40 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.2.tgz",
+      "integrity": "sha512-9XRsLwe6Yb9B/tlnYCPVUd/TFS4J7HuOZW345DCeC6vKIxQGMZdx21RK4VoZauPD5frgkXTYVS5y90L+3YBn4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.0",
+        "@radix-ui/react-compose-refs": "1.1.0",
+        "@radix-ui/react-context": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.0",
+        "@radix-ui/react-portal": "1.1.1",
+        "@radix-ui/react-presence": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.0",
+        "@radix-ui/react-slot": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-visually-hidden": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tooltip": "^1.1.2",
     "@tanstack/react-query": "^5.50.1",
     "@types/node": "20.14.9",
     "@types/react": "18.3.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,8 +32,10 @@ export default function RootLayout({
       <body className={pretendard.className}>
         <QueryProvider>
           <div className="w-96 mx-auto bg-white min-h-full flex flex-col">
-            {pathname === '/main' || pathname === '/signIn' ? (
+            {pathname === '/main' ? (
               <MainHeader />
+            ) : pathname === '/signIn' ? (
+              ''
             ) : (
               <CommonHeader />
             )}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import localFont from 'next/font/local';
 import QueryProvider from './providers/QueryProvider';
 import MainHeader from '@/widgets/Header/MainHeader';
 import Footer from '@/widgets/Footer';
+import CommonHeader from '@/widgets/Header/CommonHeader';
+import { headers } from 'next/headers';
 
 const pretendard = localFont({
   src: '../../public/static/fonts/PretendardVariable.woff2',
@@ -21,12 +23,20 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const headersList = headers();
+  const pathname = headersList.get('x-pathname');
+  console.log(pathname);
+
   return (
     <html lang="kr" className={pretendard.variable}>
       <body className={pretendard.className}>
         <QueryProvider>
           <div className="w-96 mx-auto bg-white min-h-full flex flex-col">
-            <MainHeader />
+            {pathname === '/main' || 'signIn' || 'signUp' ? (
+              <MainHeader />
+            ) : (
+              <CommonHeader />
+            )}
             <div className="p-5 flex-grow">{children}</div>
             <Footer />
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,9 @@ export default function RootLayout({
       <body className={pretendard.className}>
         <QueryProvider>
           <div className="w-96 mx-auto bg-white min-h-full flex flex-col">
-            {pathname === '/main' || 'signIn' || 'signUp' ? (
+            {pathname === '/main' ||
+            pathname === 'signIn' ||
+            pathname === 'signUp' ? (
               <MainHeader />
             ) : (
               <CommonHeader />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import './globals.css';
 import localFont from 'next/font/local';
 import QueryProvider from './providers/QueryProvider';
-import Header from '@/widgets/Header';
+import MainHeader from '@/widgets/Header/MainHeader';
 import Footer from '@/widgets/Footer';
 
 const pretendard = localFont({
@@ -26,7 +26,7 @@ export default function RootLayout({
       <body className={pretendard.className}>
         <QueryProvider>
           <div className="w-96 mx-auto bg-white min-h-full flex flex-col">
-            <Header />
+            <MainHeader />
             <div className="p-5 flex-grow">{children}</div>
             <Footer />
           </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default function RootLayout({
       <body className={pretendard.className}>
         <QueryProvider>
           <div className="w-96 mx-auto bg-white min-h-full flex flex-col">
-            {pathname === '/main' || 'signIn' || 'signUp' ? (
+            {pathname === '/main' || pathname === '/signIn' ? (
               <MainHeader />
             ) : (
               <CommonHeader />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,9 +32,7 @@ export default function RootLayout({
       <body className={pretendard.className}>
         <QueryProvider>
           <div className="w-96 mx-auto bg-white min-h-full flex flex-col">
-            {pathname === '/main' ||
-            pathname === 'signIn' ||
-            pathname === 'signUp' ? (
+            {pathname === '/main' || 'signIn' || 'signUp' ? (
               <MainHeader />
             ) : (
               <CommonHeader />

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+
+export function middleware(request: {
+  headers: HeadersInit | undefined;
+  nextUrl: { pathname: string };
+}) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set('x-pathname', request.nextUrl.pathname);
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+}

--- a/src/shared/ui/ui/tooltip.tsx
+++ b/src/shared/ui/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+import { cn } from '@/shared/lib/utils';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Content
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      'z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+      className,
+    )}
+    {...props}
+  />
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/src/widgets/Header.tsx
+++ b/src/widgets/Header.tsx
@@ -1,5 +1,0 @@
-const Header = () => {
-  return <div className="h-[50px] bg-gray-200">Header</div>;
-};
-
-export default Header;

--- a/src/widgets/Header/CommonHeader.tsx
+++ b/src/widgets/Header/CommonHeader.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Button } from '@/shared/ui/ui/button';
+import {
+  TooltipProvider,
+  TooltipTrigger,
+  TooltipContent,
+  Tooltip,
+} from '@/shared/ui/ui/tooltip';
+import { usePathname } from 'next/navigation';
+import { FaUserLarge } from 'react-icons/fa6';
+import { IoIosArrowBack } from 'react-icons/io';
+
+const CommonHeader = () => {
+  let pathname = usePathname();
+
+  const getPageName = () => {
+    switch (pathname) {
+      case '/notice':
+        return '공지사항';
+      case '/faq':
+        return 'FAQ';
+      case '/proceeding':
+        return '회의록';
+      case '/event':
+        return '행사';
+      case '/transaction':
+        return '입/출금 내역';
+      case '/profile':
+        return '마이 페이지';
+      default:
+        return ' ';
+    }
+  };
+  return (
+    <div className="h-[50px] bg-white top-0 border-y sticky z-10 flex justify-between items-center px-2">
+      <Button variant="link">
+        {
+          <IoIosArrowBack
+            size="20"
+            className="text-gray-200 hover:text-blue-500"
+          />
+        }
+      </Button>
+      <p className="text-lg font-bold text-blue-500">{getPageName()}</p>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="link">
+              {
+                <FaUserLarge
+                  size="16"
+                  className="text-gray-200 hover:opacity-50"
+                />
+              }
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent className="relative -ml-5">
+            <p>마이페이지</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+};
+
+export default CommonHeader;

--- a/src/widgets/Header/CommonHeader.tsx
+++ b/src/widgets/Header/CommonHeader.tsx
@@ -7,7 +7,9 @@ import {
   TooltipContent,
   Tooltip,
 } from '@/shared/ui/ui/tooltip';
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { FaUserLarge } from 'react-icons/fa6';
 import { IoIosArrowBack } from 'react-icons/io';
 
@@ -34,30 +36,33 @@ const CommonHeader = () => {
         return ' ';
     }
   };
+
+  const router = useRouter();
+
+  const handleGoBack = () => {
+    router.back();
+  };
+
   return (
     <div className="h-[50px] bg-white top-0 border-y sticky z-10 flex justify-between items-center px-2">
-      <Button variant="link">
-        {
-          <IoIosArrowBack
-            size="20"
-            className="text-gray-200 hover:text-blue-500"
-          />
-        }
+      <Button variant="link" onClick={handleGoBack}>
+        <IoIosArrowBack
+          size="20"
+          className="text-gray-200 hover:text-blue-500"
+        />
       </Button>
       <p className="text-lg font-bold text-blue-500">{getPageName()}</p>
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <Button variant="link">
-              {
-                <FaUserLarge
-                  size="16"
-                  className="text-gray-200 hover:opacity-50"
-                />
-              }
-            </Button>
+            <Link href="/profile">
+              <FaUserLarge
+                size="16"
+                className="text-gray-200 hover:opacity-50 mr-3"
+              />
+            </Link>
           </TooltipTrigger>
-          <TooltipContent className="relative -ml-5">
+          <TooltipContent className="relative -ml-10">
             <p>마이페이지</p>
           </TooltipContent>
         </Tooltip>

--- a/src/widgets/Header/CommonHeader.tsx
+++ b/src/widgets/Header/CommonHeader.tsx
@@ -28,6 +28,8 @@ const CommonHeader = () => {
         return '입/출금 내역';
       case '/profile':
         return '마이 페이지';
+      case '/signUp':
+        return '회원가입';
       default:
         return ' ';
     }

--- a/src/widgets/Header/MainHeader.tsx
+++ b/src/widgets/Header/MainHeader.tsx
@@ -24,23 +24,19 @@ const MainHeader = () => {
         <Link href="/main">Big Brother</Link>
       </Button>
       <TooltipProvider>
-        {pathname === '/signUp' ? (
-          ''
-        ) : (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Link href="/profile">
-                <FaUserLarge
-                  size="16"
-                  className="text-gray-200 hover:opacity-50 mr-3"
-                />
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent className="relative -ml-10">
-              <p>마이페이지</p>
-            </TooltipContent>
-          </Tooltip>
-        )}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link href="/profile">
+              <FaUserLarge
+                size="16"
+                className="text-gray-200 hover:opacity-50 mr-3"
+              />
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent className="relative -ml-10">
+            <p>마이페이지</p>
+          </TooltipContent>
+        </Tooltip>
       </TooltipProvider>
     </div>
   );

--- a/src/widgets/Header/MainHeader.tsx
+++ b/src/widgets/Header/MainHeader.tsx
@@ -24,7 +24,7 @@ const MainHeader = () => {
         <Link href="/main">Big Brother</Link>
       </Button>
       <TooltipProvider>
-        {pathname === '/signUp' || pathname === '/signIn' ? (
+        {pathname === '/signUp' ? (
           ''
         ) : (
           <Tooltip>

--- a/src/widgets/Header/MainHeader.tsx
+++ b/src/widgets/Header/MainHeader.tsx
@@ -16,13 +16,9 @@ const MainHeader = () => {
 
   return (
     <div className="h-[50px] bg-white top-0 border-y sticky z-10 flex justify-between items-center px-2">
-      <Button
-        variant="link"
-        asChild
-        className="text-xl font-bold text-blue-500 hover:no-underline"
-      >
-        <Link href="/main">Big Brother</Link>
-      </Button>
+      <p className="text-xl font-bold text-blue-500 ml-4 cursor-default">
+        Big Brother
+      </p>
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/widgets/Header/MainHeader.tsx
+++ b/src/widgets/Header/MainHeader.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Button } from '@/shared/ui/ui/button';
 import {
   TooltipProvider,
   TooltipTrigger,
@@ -8,12 +7,9 @@ import {
   Tooltip,
 } from '@/shared/ui/ui/tooltip';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { FaUserLarge } from 'react-icons/fa6';
 
 const MainHeader = () => {
-  let pathname = usePathname();
-
   return (
     <div className="h-[50px] bg-white top-0 border-y sticky z-10 flex justify-between items-center px-2">
       <p className="text-xl font-bold text-blue-500 ml-4 cursor-default">

--- a/src/widgets/Header/MainHeader.tsx
+++ b/src/widgets/Header/MainHeader.tsx
@@ -1,0 +1,40 @@
+import { Button } from '@/shared/ui/ui/button';
+import {
+  TooltipProvider,
+  TooltipTrigger,
+  TooltipContent,
+  Tooltip,
+} from '@/shared/ui/ui/tooltip';
+import { FaUserLarge } from 'react-icons/fa6';
+
+const MainHeader = () => {
+  return (
+    <div className="h-[50px] bg-white top-0 border-y sticky z-10 flex justify-between items-center px-2">
+      <Button
+        variant="link"
+        className="text-xl font-bold text-blue-500 hover:no-underline"
+      >
+        Big Brother
+      </Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="link">
+              {
+                <FaUserLarge
+                  size="16"
+                  className="text-gray-200 hover:opacity-50"
+                />
+              }
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent className="relative -ml-5">
+            <p>마이페이지</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+};
+
+export default MainHeader;

--- a/src/widgets/Header/MainHeader.tsx
+++ b/src/widgets/Header/MainHeader.tsx
@@ -7,6 +7,7 @@ import {
   TooltipContent,
   Tooltip,
 } from '@/shared/ui/ui/tooltip';
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { FaUserLarge } from 'react-icons/fa6';
 
@@ -17,9 +18,10 @@ const MainHeader = () => {
     <div className="h-[50px] bg-white top-0 border-y sticky z-10 flex justify-between items-center px-2">
       <Button
         variant="link"
+        asChild
         className="text-xl font-bold text-blue-500 hover:no-underline"
       >
-        Big Brother
+        <Link href="/main">Big Brother</Link>
       </Button>
       <TooltipProvider>
         {pathname === '/signUp' || pathname === '/signIn' ? (
@@ -27,14 +29,14 @@ const MainHeader = () => {
         ) : (
           <Tooltip>
             <TooltipTrigger asChild>
-              <Button variant="link">
+              <Link href="/profile">
                 <FaUserLarge
                   size="16"
-                  className="text-gray-200 hover:opacity-50"
+                  className="text-gray-200 hover:opacity-50 mr-3"
                 />
-              </Button>
+              </Link>
             </TooltipTrigger>
-            <TooltipContent className="relative -ml-5">
+            <TooltipContent className="relative -ml-10">
               <p>마이페이지</p>
             </TooltipContent>
           </Tooltip>

--- a/src/widgets/Header/MainHeader.tsx
+++ b/src/widgets/Header/MainHeader.tsx
@@ -17,6 +17,7 @@ const MainHeader = () => {
         Big Brother
       </Button>
       <TooltipProvider>
+        {/**로그인, 회원가입 화면에서는 없어야 함 */}
         <Tooltip>
           <TooltipTrigger asChild>
             <Button variant="link">

--- a/src/widgets/Header/MainHeader.tsx
+++ b/src/widgets/Header/MainHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Button } from '@/shared/ui/ui/button';
 import {
   TooltipProvider,
@@ -5,9 +7,13 @@ import {
   TooltipContent,
   Tooltip,
 } from '@/shared/ui/ui/tooltip';
+import { usePathname } from 'next/navigation';
 import { FaUserLarge } from 'react-icons/fa6';
 
 const MainHeader = () => {
+  let pathname = usePathname();
+  console.log(pathname);
+
   return (
     <div className="h-[50px] bg-white top-0 border-y sticky z-10 flex justify-between items-center px-2">
       <Button
@@ -17,22 +23,23 @@ const MainHeader = () => {
         Big Brother
       </Button>
       <TooltipProvider>
-        {/**로그인, 회원가입 화면에서는 없어야 함 */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="link">
-              {
+        {pathname === '/signUp' || pathname === '/signIn' ? (
+          ''
+        ) : (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="link">
                 <FaUserLarge
                   size="16"
                   className="text-gray-200 hover:opacity-50"
                 />
-              }
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent className="relative -ml-5">
-            <p>마이페이지</p>
-          </TooltipContent>
-        </Tooltip>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent className="relative -ml-5">
+              <p>마이페이지</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
       </TooltipProvider>
     </div>
   );

--- a/src/widgets/Header/MainHeader.tsx
+++ b/src/widgets/Header/MainHeader.tsx
@@ -12,7 +12,6 @@ import { FaUserLarge } from 'react-icons/fa6';
 
 const MainHeader = () => {
   let pathname = usePathname();
-  console.log(pathname);
 
   return (
     <div className="h-[50px] bg-white top-0 border-y sticky z-10 flex justify-between items-center px-2">


### PR DESCRIPTION
close #12 

- npm i 필요 (shadcn tooltip 설치)

- 로그인 화면에서는 헤더 없음
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/418787d2-ca3d-47b0-966b-3183c644b864">

<br/>
<br/>

- 메인 화면
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/2b375920-b5a4-4335-824f-2b390111bcf7">

<br/>
<br/>

- 공지 사항 (행사, 회칙/학칙, 회의록, 입 출금 내역, 회원가입 페이지도 동일 (text만 바뀜))
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/d18b48bb-3c13-4619-a99b-4ac422eedc2c">
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/ae68a7d6-d340-4858-9002-5fce964daced">
