### PR TITLE
7m4w 회의 후 변경사항

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { Button } from '@/shared/ui/ui/button';
+import { Input } from '@/shared/ui/ui/input';
+import { useState } from 'react';
+
+const page = () => {
+  const [isValid, setIsValid] = useState(true);
+
+  return (
+    <div className="flex flex-col space-y-15">
+      <div className="flex flex-col space-y-5">
+        <div>
+          <p>이메일을 입력하세요.</p>
+          <Input type="email" />
+        </div>
+        <Button className="w-full">확인</Button>
+      </div>
+      {isValid && (
+        <div className="flex flex-col space-y-5  mt-16">
+          <div>
+            <p>새 비밀번호 입력</p>
+            <Input type="password" />
+          </div>
+          <Button className="w-full">변경하기</Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default page;

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -61,9 +61,10 @@ const Page = () => {
                       {...field}
                     />
                   </FormControl>
-                  <Button variant="outline">인증번호 발송</Button>
+                  <Button variant="outline">중복 확인</Button>
                 </div>
                 <FormMessage />
+                <Button variant="secondary">인증번호 발송</Button>
               </FormItem>
             )}
           />

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -38,9 +38,9 @@ const Page = () => {
             name="username"
             render={({ field }) => (
               <FormItem>
-                <FormLabel>닉네임</FormLabel>
+                <FormLabel>이름</FormLabel>
                 <FormControl>
-                  <Input placeholder="알파벳 대/소문자, 한글" {...field} />
+                  <Input placeholder="한글" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -90,7 +90,7 @@ const Page = () => {
                 <FormControl>
                   <Input
                     type="password"
-                    placeholder="알파벳 대/소문자, 숫자 조합"
+                    placeholder="알파벳 소문자, 숫자, 특수문자 조합 (8~20자)"
                     {...field}
                   />
                 </FormControl>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -55,7 +55,7 @@ const page = () => {
         <div className="flex justify-center items-center mt-1">
           <p className="text-sm">비밀번호를 잊으셨나요?</p>
           <Button variant="link" className="text-blue-300">
-            <Link href="/join">비밀번호 변경</Link>
+            <Link href="/account">비밀번호 변경</Link>
           </Button>
         </div>
       </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,11 +16,11 @@ const page = () => {
   const form = useForm();
   return (
     <>
-      <div className="flex flex-col justify-center items-center mt-20">
+      <div className="flex flex-col justify-center items-center mt-14 ">
         <div className="w-28 h-28 bg-gray-100 mb-16">아이콘 자리</div>
         <Form {...form}>
           <form
-            className="space-y-4 mt-2"
+            className="space-y-4 mt-2 w-full"
             onSubmit={form.handleSubmit((data) => console.log(data))}
           >
             <FormField
@@ -47,17 +47,25 @@ const page = () => {
                 </FormItem>
               )}
             />
-            <Button type="submit" size="long">
+            <Button type="submit" className="w-full">
               로그인
             </Button>
           </form>
         </Form>
+        <div className="flex justify-center items-center mt-1">
+          <p className="text-sm">비밀번호를 잊으셨나요?</p>
+          <Button variant="link" className="text-blue-300">
+            <Link href="/join">비밀번호 변경</Link>
+          </Button>
+        </div>
       </div>
-      <div className="flex justify-center items-center mt-1">
-        <p className="text-sm">아직 회원이 아니라면?</p>
-        <Button variant="link" className="text-blue-300">
-          <Link href="/join">회원가입</Link>
-        </Button>
+      <div className="flex flex-col mt-10 space-y-3">
+        <p className="text-lg font-bold">아직 회원이 아니시라면,</p>
+        <Link href="/join">
+          <Button variant="secondary" className="w-full">
+            회원가입
+          </Button>
+        </Link>
       </div>
     </>
   );

--- a/src/widgets/Header/CommonHeader.tsx
+++ b/src/widgets/Header/CommonHeader.tsx
@@ -56,7 +56,7 @@ const CommonHeader = () => {
         />
       </Button>
       <p className="text-lg font-bold text-blue-500">{getPageName()}</p>
-      {pathname !== '/join' ? (
+      {pathname !== '/join' && pathname !== '/account' ? (
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>


### PR DESCRIPTION
close #48

- 회원가입 화면 (정규식 placeholder 수정, 이메일 중복 조회 추가)
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/014a7689-4d11-4530-abad-ab0a8dc590e8">

<br/>
<br/>

- 로그인 화면
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/e7b055d0-813d-432f-a175-a0d9969dd59a">


<br/>
<br/>


- 비밀번호 변경 화면
  - 가입한 이메일이 있으면 변경하는 div가 뜨도록 (지금은 useState boolean true로 그냥 보이게 해둔 상태)
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/965aefe4-ec40-4966-8348-efb796ccc6fa">
